### PR TITLE
Move linebreak between subs into SubRipFile

### DIFF
--- a/pysrt/srtfile.py
+++ b/pysrt/srtfile.py
@@ -219,6 +219,12 @@ class SubRipFile(UserList, object):
             if output_eol != '\n':
                 string_repr = string_repr.replace('\n', output_eol)
             output_file.write(string_repr)
+            # Only add trailing eol if it's not already present.
+            # It was kept in the SubRipItem's text before but it really
+            # belongs here. Existing applications might give us subtitles
+            # which already contain a trailing eol though.
+            if not string_repr.endswith(2 * output_eol):
+                output_file.write(output_eol)
 
     @classmethod
     def _guess_eol(cls, string_iterable):

--- a/pysrt/srtitem.py
+++ b/pysrt/srtitem.py
@@ -51,10 +51,10 @@ class SubRipItem(object):
     def from_lines(cls, lines):
         if len(lines) < 3:
             raise InvalidItem()
-        lines = [l.replace('\r', '') for l in lines]
+        lines = [l.rstrip() for l in lines]
         index = lines[0]
         start, end, position = cls.split_timestamps(lines[1])
-        body = u''.join(lines[2:])
+        body = u'\n'.join(lines[2:])
         return cls(index, start, end, body, position)
 
     @staticmethod

--- a/tests/test_srtitem.py
+++ b/tests/test_srtitem.py
@@ -99,13 +99,13 @@ class TestSerialAndParsing(unittest.TestCase):
         vtt = SubRipItem.from_string(self.vtt)
         self.assertEquals(vtt.position, 'D:vertical A:start L:12%')
         self.assertEquals(vtt.index, 1)
-        self.assertEquals(vtt.text, 'Hello world !\n')
+        self.assertEquals(vtt.text, 'Hello world !')
 
     def test_idempotence(self):
         vtt = SubRipItem.from_string(self.vtt)
-        self.assertEquals(unicode(vtt), self.vtt + '\n')
+        self.assertEquals(unicode(vtt), self.vtt)
         item = SubRipItem.from_string(self.coordinates)
-        self.assertEquals(unicode(item), self.coordinates + '\n')
+        self.assertEquals(unicode(item), self.coordinates)
 
     def test_dots(self):
         self.assertEquals(SubRipItem.from_string(self.dots), self.item)


### PR DESCRIPTION
- it used to be part of the SubRipItem.text but since it's not related
  to a single entry at all it doesn't belong there
- for backwards compatibility, a SubRipItem with a trailing linebreak
  will not have another one added.
