### PR TITLE
SubRipFile text_at_time() method

### DIFF
--- a/pysrt/srtfile.py
+++ b/pysrt/srtfile.py
@@ -13,6 +13,7 @@ except ImportError: # For python < 2.6
 
 from pysrt.srtexc import Error
 from pysrt.srtitem import SubRipItem
+from pysrt.srttime import SubRipTime
 
 BOMS = [(codecs.BOM_UTF16_LE, 'utf_16_le'),
         (codecs.BOM_UTF16_BE, 'utf_16_be'),
@@ -140,6 +141,19 @@ class SubRipFile(UserList, object):
         self.sort()
         for index, item in enumerate(self):
             item.index = index + 1
+
+    def text_at_time(self, time):
+        """
+        text_at_time()
+
+        Get text that, according to subtitles, should appear on screen
+        exactly at given time.
+        """
+        time = SubRipTime.coerce(time)
+
+        for item in self:
+            if item.start <= time and time <= item.end:
+                return item.text
 
     @classmethod
     def open(cls, path='', encoding=None, error_handling=ERROR_PASS):

--- a/tests/test_srtfile.py
+++ b/tests/test_srtfile.py
@@ -181,6 +181,22 @@ class TestCleanIndexes(unittest.TestCase):
             self.assertTrue(first <= second)
 
 
+class TestTextAtTime(unittest.TestCase):
+
+    def setUp(self):
+        self.file = SubRipFile.open(os.path.join(file_path, 'tests', 'static',
+            'utf-8.srt'))
+
+    def test_text_at_time(self):
+        self.assertEquals(self.file.text_at_time(SubRipTime(0, 1, 14, 20)),
+                          u'Ron Burgundy.')
+        self.assertEquals(self.file.text_at_time(SubRipTime(0, 1, 16, 11)),
+                          u'Ron Burgundy.')
+        self.assertTrue(self.file.text_at_time(SubRipTime(0, 1, 16, 12)) is None)
+        self.assertTrue(self.file.text_at_time(SubRipTime(2, 0, 0, 0)) is None)
+        self.assertTrue(self.file.text_at_time(-1) is None)
+
+
 class TestBOM(unittest.TestCase):
     "In response of issue #6 https://github.com/byroot/pysrt/issues/6"
 


### PR DESCRIPTION
Hi!
First of all, let me say you've done great job on the library, I really like the ease of use.

Few days back I found myself looking for a method to extract subtitle text that, when watching a movie, would appear on the screen at particular time (say, '00:15:42,500'). The motivation is simple: I learn languages by watching movies, and I wanted to have a clean way to quickly translate text that appears on the screen. vlc is my weapon of choice; I get the current position (time) via dbus, then pysrt magic happens and finally the translation pops out in translate.google right in my browser.

Anyway, it's simple as can be. Maybe someone else would also benefit?
