### PR TITLE
Handle division by zero in characters_per_second

### DIFF
--- a/pysrt/srtitem.py
+++ b/pysrt/srtitem.py
@@ -38,7 +38,10 @@ class SubRipItem(ComparableMixin):
     @property
     def characters_per_second(self):
         characters_count = len(self.text.replace('\n', ''))
-        return characters_count / (self.duration.ordinal / 1000.0)
+        try:
+            return characters_count / (self.duration.ordinal / 1000.0)
+        except ZeroDivisionError:
+            return 0.0
 
     def __str__(self):
         position = ' %s' % self.position if self.position.strip() else ''

--- a/tests/test_srtitem.py
+++ b/tests/test_srtitem.py
@@ -59,6 +59,10 @@ class TestCPS(unittest.TestCase):
         self.item.text = "Hello world !\nHello world again !"
         self.assertEqual(self.item.characters_per_second, 1.6)
 
+    def test_zero_duration(self):
+        self.item.start.shift(seconds = 20)
+        self.assertEqual(self.item.characters_per_second, 0.0)
+
 
 class TestShifting(unittest.TestCase):
 


### PR DESCRIPTION
When duration is 0, the program used to throw an error. Now it returns 0. I am not sure if that is the best value to return (float('inf') could be used maybe) but cannot think of anything better and this seems better than throwing an exception.  
