### PR TITLE
Make str() method of SrtItem function properly in both Python 2 and 3

### DIFF
--- a/pysrt/srtitem.py
+++ b/pysrt/srtitem.py
@@ -2,6 +2,8 @@
 """
 SubRip's subtitle parser
 """
+
+import sys
 from pysrt.srtexc import InvalidItem, InvalidIndex
 from pysrt.srttime import SubRipTime
 from pysrt.comparablemixin import ComparableMixin
@@ -40,10 +42,19 @@ class SubRipItem(ComparableMixin):
         characters_count = len(self.text.replace('\n', ''))
         return characters_count / (self.duration.ordinal / 1000.0)
 
-    def __str__(self):
-        position = ' %s' % self.position if self.position.strip() else ''
-        return self.ITEM_PATTERN % (self.index, self.start, self.end,
-                                    position, self.text)
+    if sys.version_info[0] == 3:
+        def __str__(self):
+            position = ' %s' % self.position if self.position.strip() else ''
+            return self.ITEM_PATTERN % (self.index, self.start, self.end,
+                                        position, self.text)
+    else:                
+        def __unicode__(self):
+            position = ' %s' % self.position if self.position.strip() else ''
+            return self.ITEM_PATTERN % (self.index, self.start, self.end,
+                                        position, self.text)
+        def __str__(self):
+            raise NotImplementedError("Use unicode() instead!")
+
 
     def _cmpkey(self):
         return (self.start, self.end)

--- a/tests/test_srtitem.py
+++ b/tests/test_srtitem.py
@@ -10,6 +10,7 @@ sys.path.insert(0, os.path.abspath(file_path))
 
 from pysrt import SubRipItem, SubRipTime, InvalidItem
 from pysrt.compat import basestring
+from pysrt.compat import str
 
 
 class TestAttributes(unittest.TestCase):


### PR DESCRIPTION
My try to fix https://github.com/byroot/pysrt/issues/50
I am not very happy as printing SubRipItem now raises an exception, but at least it does not fail mysteriously.
