### PR TITLE
Add parent, previous and next properties to SubRipItem

### DIFF
--- a/pysrt/srtfile.py
+++ b/pysrt/srtfile.py
@@ -178,11 +178,11 @@ class SubRipFile(UserList, object):
             opened with `codecs.open()` or an array of unicode.
         """
         self.eol = self._guess_eol(source_file)
-        self.extend(self.stream(source_file, error_handling=error_handling))
+        self.extend(self.stream(source_file, error_handling=error_handling, parent=self))
         return self
 
     @classmethod
-    def stream(cls, source_file, error_handling=ERROR_PASS):
+    def stream(cls, source_file, error_handling=ERROR_PASS, parent=None):
         """
         stream(source_file, [error_handling])
 
@@ -209,7 +209,7 @@ class SubRipFile(UserList, object):
                 string_buffer = []
                 if source and all(source):
                     try:
-                        yield SubRipItem.from_lines(source)
+                        yield SubRipItem.from_lines(source, parent)
                     except Error as error:
                         error.args += (''.join(source), )
                         cls._handle_error(error, error_handling, index)


### PR DESCRIPTION
This works for me so far. However, it is for sure incomplete:

1) No testcases.
2) When SubRipItem is inserted into another SubRipFile or is removed from its original, the parent property does not change.

I also noticed that SubRipFile accepts input as a list, so one can add 1 or "bla" to it even though it does not make much sense. Maybe it would be worthwhile to override insert() append() and extend() (and remove()) methods so that they would update the parent property of added elements and would check if we are operating with SubRipItem instances and raise an error if not? What do you think?
