### PR TITLE
Make character_per_seconds correctly deal with tags and introduce text_w...

### DIFF
--- a/pysrt/srtitem.py
+++ b/pysrt/srtitem.py
@@ -7,6 +7,7 @@ from pysrt.srtexc import InvalidItem, InvalidIndex
 from pysrt.srttime import SubRipTime
 from pysrt.comparablemixin import ComparableMixin
 from pysrt.compat import str, is_py2
+import re
 
 
 class SubRipItem(ComparableMixin):
@@ -37,8 +38,13 @@ class SubRipItem(ComparableMixin):
         return self.end - self.start
 
     @property
+    def text_without_tags(self):
+        RE_TAG = re.compile(r'<[^>]*?>')
+        return RE_TAG.sub('', self.text)
+
+    @property
     def characters_per_second(self):
-        characters_count = len(self.text.replace('\n', ''))
+        characters_count = len(self.text_without_tags.replace('\n', ''))
         try:
             return characters_count / (self.duration.ordinal / 1000.0)
         except ZeroDivisionError:

--- a/tests/test_srtitem.py
+++ b/tests/test_srtitem.py
@@ -64,6 +64,43 @@ class TestCPS(unittest.TestCase):
         self.item.start.shift(seconds = 20)
         self.assertEqual(self.item.characters_per_second, 0.0)
 
+    def test_tags(self):
+	    self.item.text = '<b>bold</b>, <i>italic</i>, <u>underlined</u>\n' + \
+	    '<font color="#ff0000">red text</font>' + \
+	    ', <b>one,<i> two,<u> three</u></i></b>'
+	    self.assertEqual(self.item.characters_per_second, 2.45)
+
+
+class TestTagRemoval(unittest.TestCase):
+
+    def setUp(self):
+        self.item = SubRipItem(1, text="Hello world !")
+        self.item.shift(minutes=1)
+        self.item.end.shift(seconds=20)
+
+    def test_italics_tag(self):
+        self.item.text = "<i>Hello world !</i>"
+        self.assertEqual(self.item.text_without_tags,'Hello world !')
+        
+    def test_bold_tag(self):
+        self.item.text = "<b>Hello world !</b>"
+        self.assertEqual(self.item.text_without_tags,'Hello world !')
+
+    def test_underline_tag(self):
+        self.item.text = "<u>Hello world !</u>"
+        self.assertEqual(self.item.text_without_tags,'Hello world !')
+
+    def test_color_tag(self):
+        self.item.text = '<font color="#ff0000">Hello world !</font>'
+        self.assertEqual(self.item.text_without_tags,'Hello world !')
+
+    def test_all_tags(self):
+        self.item.text = '<b>Bold</b>, <i>italic</i>, <u>underlined</u>\n' + \
+        '<font color="#ff0000">red text</font>' + \
+        ', <b>one,<i> two,<u> three</u></i></b>.'
+        self.assertEqual(self.item.text_without_tags,'Bold, italic, underlined' + \
+                '\nred text, one, two, three.')
+
 
 class TestShifting(unittest.TestCase):
 


### PR DESCRIPTION
BTW: is not the commit message too long? Github truncates it.

This ignores tags that srt format allows. It could be done with one regular expression, but I wanted to be explicit in what is ignored (and replace is faster then re, but as it gets called several times, I guess this is overall slower).

SRT is also said to support position coordinates, but there are several ways to write them and I have never actually seen them in the wild, unlike other tags.
