### PR TITLE
Fixed rate command

### DIFF
--- a/pysrt/srttime.py
+++ b/pysrt/srttime.py
@@ -93,6 +93,20 @@ class SubRipTime(ComparableMixin):
         self.ordinal = int(round(self.ordinal * ratio))
         return self
 
+    def __div__(self, ratio):
+        return self.from_ordinal(int(round(self.ordinal / ratio)))
+
+    def __idiv__(self, ratio):
+        self.ordinal = int(round(self.ordinal / ratio))
+        return self
+
+    def __truediv__(self, ratio):
+        return self.from_ordinal(int(round(self.ordinal / ratio)))
+
+    def __itruediv__(self, ratio):
+        self.ordinal = int(round(self.ordinal / ratio))
+        return self
+
     @classmethod
     def coerce(cls, other):
         """
@@ -130,7 +144,7 @@ class SubRipTime(ComparableMixin):
         All arguments are optional and have a default value of 0.
         """
         if 'ratio' in kwargs:
-            self *= kwargs.pop('ratio')
+            self /= kwargs.pop('ratio')
         self += self.__class__(*args, **kwargs)
 
     @classmethod


### PR DESCRIPTION
If ratio is `final/initial` then time should be divided by it, not multiplied.