### PR TITLE
IOError: [Errno 2] No such file or directory

### DIFF
--- a/pysrt/commands.py
+++ b/pysrt/commands.py
@@ -132,9 +132,14 @@ class SubRipShifter(object):
 
     def run(self, args):
         self.arguments = self.build_parser().parse_args(args)
-        if self.arguments.in_place:
-            self.create_backup()
-        self.arguments.action()
+
+        if os.path.isfile(self.arguments.file):
+            if self.arguments.in_place:
+                self.create_backup()
+            self.arguments.action()
+
+        else:
+            print 'No such file', self.arguments.file
 
     def parse_time(self, time_string):
         negative = time_string.startswith('-')

--- a/pysrt/commands.py
+++ b/pysrt/commands.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # pylint: disable-all
+from __future__ import print_function
 
 import os
 import re
@@ -139,7 +140,7 @@ class SubRipShifter(object):
             self.arguments.action()
 
         else:
-            print 'No such file', self.arguments.file
+            print('No such file', self.arguments.file)
 
     def parse_time(self, time_string):
         negative = time_string.startswith('-')


### PR DESCRIPTION
If I use `pysrt` with a not existed file I get this error message 

```
$ srt -i shift 3s hello.txt
Traceback (most recent call last):
  File "/Users/pablo/.envs/pysrt/bin/srt", line 9, in <module>
    load_entry_point('pysrt', 'console_scripts', 'srt')()
  File "/Users/pablo/src/pysrt/pysrt/commands.py", line 216, in main
    SubRipShifter().run(sys.argv[1:])
  File "/Users/pablo/src/pysrt/pysrt/commands.py", line 136, in run
    self.create_backup()
  File "/Users/pablo/src/pysrt/pysrt/commands.py", line 176, in create_backup
    shutil.copy2(self.arguments.file, backup_file)
  File "/Users/pablo/opt/src/homebrew/Cellar/python/2.7.11/Frameworks/Python.framework/Versions/2.7/lib/python2.7/shutil.py", line 130, in copy2
    copyfile(src, dst)
  File "/Users/pablo/opt/src/homebrew/Cellar/python/2.7.11/Frameworks/Python.framework/Versions/2.7/lib/python2.7/shutil.py", line 82, in copyfile
    with open(src, 'rb') as fsrc:
IOError: [Errno 2] No such file or directory: 'hello.txt'
```

This changes fix the error message, but I use the `print` of python 2.7 ... this print don't work in python 3.x