### PR TITLE
remove_overlaps and to_string

### DIFF
--- a/pysrt/srtfile.py
+++ b/pysrt/srtfile.py
@@ -191,7 +191,6 @@ class SubRipFile(UserList, object):
             
             if current_start >= current_end:
                 self.pop(i)
-                self.clean_indexes()
             
             else:
                 self[i].start.from_millis(current_start)

--- a/pysrt/srtfile.py
+++ b/pysrt/srtfile.py
@@ -166,6 +166,36 @@ class SubRipFile(UserList, object):
         new_file = cls(**kwargs)
         new_file.read(source.splitlines(True), error_handling=error_handling)
         return new_file
+    
+    def to_string(self):
+        """
+        returns the subtitles as a string
+        """
+        output = []
+        for sub in self:
+            output.append(str(sub))        
+        return '\n'.join(output)
+    
+    def remove_overlaps(self):
+        """
+        Adjusts start times of overlapping subtitles to remove overlap
+        """
+        i = 1
+        while i < len(self):
+            previous_end = self[i - 1].end.to_millis()
+            current_start = self[i].start.to_millis()
+            current_end = self[i].end.to_millis()
+            
+            if current_start <= previous_end:
+                current_start = previous_end + 1
+            
+            if current_start >= current_end:
+                self.pop(i)
+                self.clean_indexes()
+            
+            else:
+                self[i].start.from_millis(current_start)
+                i += 1
 
     def read(self, source_file, error_handling=ERROR_PASS):
         """

--- a/pysrt/srtfile.py
+++ b/pysrt/srtfile.py
@@ -186,7 +186,7 @@ class SubRipFile(UserList, object):
             current_start = self[i].start.to_millis()
             current_end = self[i].end.to_millis()
             
-            if current_start <= previous_end:
+            if current_start < previous_end:
                 current_start = previous_end + 1
                 self[i].start.from_millis(current_start)
             

--- a/pysrt/srtfile.py
+++ b/pysrt/srtfile.py
@@ -187,7 +187,7 @@ class SubRipFile(UserList, object):
             current_end = self[i].end.to_millis()
             
             if current_start < previous_end:
-                current_start = previous_end + 1
+                current_start = previous_end
                 self[i].start.from_millis(current_start)
             
             if current_start >= current_end:

--- a/pysrt/srtfile.py
+++ b/pysrt/srtfile.py
@@ -188,12 +188,12 @@ class SubRipFile(UserList, object):
             
             if current_start <= previous_end:
                 current_start = previous_end + 1
+                self[i].start.from_millis(current_start)
             
             if current_start >= current_end:
                 self.pop(i)
             
             else:
-                self[i].start.from_millis(current_start)
                 i += 1
 
     def read(self, source_file, error_handling=ERROR_PASS):

--- a/pysrt/srttime.py
+++ b/pysrt/srttime.py
@@ -175,3 +175,38 @@ class SubRipTime(ComparableMixin):
         """
         return time(self.hours, self.minutes, self.seconds,
                     self.milliseconds * 1000)
+
+    def to_millis(self):
+        """
+        Returns SubRipTime corresponding to a total count of milliseconds
+        """
+        total_millis = sum([
+            self.milliseconds,
+            self.seconds * 1000,
+            self.minutes * 60 * 1000,
+            self.hours * 60 * 60 * 1000
+            ])
+        return total_millis
+    
+    def from_millis(self, total_millis):
+        """
+        Sets the hours, minutes, seconds, & milliseconds from total 
+        milliseconds
+        """
+        millis_per_hour = 60 * 60 * 100
+        millis_per_min = 60 * 1000
+        millis_per_sec = 1000
+        
+        hours = int(total_millis / millis_per_hour)
+        remainder = total_millis % millis_per_hour
+        
+        minutes = int(remainder / millis_per_min)
+        remainder = remainder % millis_per_min
+        
+        seconds = int(remainder / millis_per_sec)
+        milliseconds = remainder % millis_per_sec
+        
+        self.hours = hours
+        self.minutes = minutes
+        self.seconds = seconds
+        self.milliseconds = milliseconds

--- a/tests/static/overlapping-dialogues.srt
+++ b/tests/static/overlapping-dialogues.srt
@@ -1,0 +1,17 @@
+﻿1
+00:00:0,000 --> 00:00:01,000
+I am the 1st dialogue
+
+2
+00:00:00,500 --> 00:00:02,500
+I am the 2nd dialogue
+I am overlapping the 1st and 3rd
+
+3
+00:00:00,250 --> 00:00:02,300
+I am the 3rd dialogue, but I'm completely overlapped by the 2nd
+I should be removed
+
+4
+00:00:02,000 --> 00:00:03,000
+I am the 4th dialogue

--- a/tests/test_srtfile.py
+++ b/tests/test_srtfile.py
@@ -253,5 +253,23 @@ class TestIntegration(unittest.TestCase):
         items = pysrt.open(os.path.join(self.base_path, 'no-indexes.srt'))
         self.assertEquals(len(items), 7)
 
+class TestRemoveOverlaps(unittest.TestCase):
+    """
+    Test the remove_overlap function
+    """
+    
+    def setUp(self):
+        self.base_path = os.path.join(file_path, 'tests', 'static')
+    
+    def test_remove_overlaps(self):
+        path = os.path.join(self.base_path, 'overlapping-dialogues.srt')
+        file = pysrt.open(path)
+        file.remove_overlaps()
+        
+        for i in range(1, len(file)):
+            previous_end = file[i - 1].end.to_millis()
+            current_start = file[i].start.to_millis()
+            self.assertTrue(previous_end < current_start)
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_srtfile.py
+++ b/tests/test_srtfile.py
@@ -269,7 +269,7 @@ class TestRemoveOverlaps(unittest.TestCase):
         for i in range(1, len(file)):
             previous_end = file[i - 1].end.to_millis()
             current_start = file[i].start.to_millis()
-            self.assertTrue(previous_end < current_start)
+            self.assertTrue(previous_end <= current_start)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
I've created 2 new functions. 1 for removing the overlap between subtitles and another for getting the srt format as a string (as opposed to saving to a file).