### PR TITLE
open(): don't use universal 'U' mode

### DIFF
--- a/pysrt/srtfile.py
+++ b/pysrt/srtfile.py
@@ -290,7 +290,7 @@ class SubRipFile(UserList, object):
     @classmethod
     def _open_unicode_file(cls, path, claimed_encoding=None):
         encoding = claimed_encoding or cls._detect_encoding(path)
-        source_file = codecs.open(path, 'rU', encoding=encoding)
+        source_file = codecs.open(path, 'r', encoding=encoding)
 
         # get rid of BOM if any
         possible_bom = CODECS_BOMS.get(encoding, None)

--- a/tests/test_srtfile.py
+++ b/tests/test_srtfile.py
@@ -90,14 +90,14 @@ class TestSerialization(unittest.TestCase):
         os.remove(self.temp_path)
 
     def test_eol_conversion(self):
-        input_file = open(self.windows_path, 'rU', encoding='windows-1252')
+        input_file = open(self.windows_path, 'r', encoding='windows-1252')
         input_file.read()
         self.assertEqual(input_file.newlines, '\r\n')
 
         srt_file = pysrt.open(self.windows_path, encoding='windows-1252')
         srt_file.save(self.temp_path, eol='\n')
 
-        output_file = open(self.temp_path, 'rU', encoding='windows-1252')
+        output_file = open(self.temp_path, 'r', encoding='windows-1252')
         output_file.read()
         self.assertEqual(output_file.newlines, '\n')
 


### PR DESCRIPTION
The open() 'U' mode has been removed from Python 3.9.