### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ Rescaling: ::
 Installation
 =================
 
-pysrt is available on pypi. To intall it you can use either
+pysrt is available on pypi. To install it you can use either
 
 pip: ::
     

--- a/pysrt/srtexc.py
+++ b/pysrt/srtexc.py
@@ -12,7 +12,7 @@ class Error(Exception):
 
 class InvalidTimeString(Error):
     """
-    Raised when parser fail on bad formated time strings
+    Raised when parser fail on bad formatted time strings
     """
     pass
 

--- a/pysrt/srtfile.py
+++ b/pysrt/srtfile.py
@@ -35,7 +35,7 @@ class SubRipFile(UserList, object):
     items -> list of SubRipItem. Default to [].
     eol -> str: end of line character. Default to linesep used in opened file
         if any else to os.linesep.
-    path -> str: path where file will be saved. To open an existant file see
+    path -> str: path where file will be saved. To open an existent file see
         SubRipFile.open.
     encoding -> str: encoding used at file save. Default to utf-8.
     """


### PR DESCRIPTION
There are small typos in:
- README.rst
- pysrt/srtexc.py
- pysrt/srtfile.py

Fixes:
- Should read `install` rather than `intall`.
- Should read `formatted` rather than `formated`.
- Should read `existent` rather than `existant`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md