### PR TITLE
Use assertEqual instead of assertEquals for Python 3.11 compatibility.

### DIFF
--- a/tests/test_srtfile.py
+++ b/tests/test_srtfile.py
@@ -117,8 +117,8 @@ class TestSlice(unittest.TestCase):
                           459)
 
     def test_at(self):
-        self.assertEquals(len(self.file.at((0, 0, 31, 0))), 1)
-        self.assertEquals(len(self.file.at(seconds=31)), 1)
+        self.assertEqual(len(self.file.at((0, 0, 31, 0))), 1)
+        self.assertEqual(len(self.file.at(seconds=31)), 1)
 
 
 class TestShifting(unittest.TestCase):
@@ -137,14 +137,14 @@ class TestText(unittest.TestCase):
         srt_file = SubRipFile([
             SubRipItem(1, {'seconds': 1}, {'seconds': 2}, 'Hello')
         ])
-        self.assertEquals(srt_file.text, 'Hello')
+        self.assertEqual(srt_file.text, 'Hello')
 
     def test_multiple_item(self):
         srt_file = SubRipFile([
             SubRipItem(1, {'seconds': 0}, {'seconds': 3}, 'Hello'),
             SubRipItem(1, {'seconds': 1}, {'seconds': 2}, 'World !')
         ])
-        self.assertEquals(srt_file.text, 'Hello\nWorld !')
+        self.assertEqual(srt_file.text, 'Hello\nWorld !')
 
 
 class TestDuckTyping(unittest.TestCase):
@@ -251,7 +251,7 @@ class TestIntegration(unittest.TestCase):
 
     def test_missing_indexes(self):
         items = pysrt.open(os.path.join(self.base_path, 'no-indexes.srt'))
-        self.assertEquals(len(items), 7)
+        self.assertEqual(len(items), 7)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_srtitem.py
+++ b/tests/test_srtitem.py
@@ -197,17 +197,17 @@ class TestSerialAndParsing(unittest.TestCase):
 
     def test_string_index(self):
         item = SubRipItem.from_string(self.string_index)
-        self.assertEquals(item.index, 'foo')
-        self.assertEquals(item.text, 'Hello !')
+        self.assertEqual(item.index, 'foo')
+        self.assertEqual(item.text, 'Hello !')
 
     def test_no_index(self):
         item = SubRipItem.from_string(self.no_index)
-        self.assertEquals(item.index, None)
-        self.assertEquals(item.text, 'Hello world !')
+        self.assertEqual(item.index, None)
+        self.assertEqual(item.text, 'Hello world !')
 
     def test_junk_after_timestamp(self):
         item = SubRipItem.from_string(self.junk_after_timestamp)
-        self.assertEquals(item, self.item)
+        self.assertEqual(item, self.item)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #89 